### PR TITLE
Fixed element order and translation

### DIFF
--- a/controllers/RulesController.php
+++ b/controllers/RulesController.php
@@ -86,10 +86,15 @@ class ItemDuplicateCheck_RulesController extends Omeka_Controller_AbstractAction
         $options = apply_filters('elements_select_options', $options);
         // now format it like the original = set_name : element_name
         $elements = array();
-        foreach ($options as $setName => $elems) {
-            foreach ($elems as $elemId => $elemName) {
-                $elements[$elemId] = "$setName : $elemName";
+        $optgroups = get_option('show_element_set_headings');
+        if ($optgroups) {
+            foreach ($options as $setName => $elems) {
+                foreach ($elems as $elemId => $elemName) {
+                    $elements[$elemId] = "$setName : $elemName";
+                }
             }
+        } else {
+            $elements = $options;
         }
         return $elements;
     }

--- a/controllers/RulesController.php
+++ b/controllers/RulesController.php
@@ -79,9 +79,18 @@ class ItemDuplicateCheck_RulesController extends Omeka_Controller_AbstractAction
     {
         $db = get_db();
         $table = $db->getTable('Element');
-        $select = $table->getSelect();
-        $select->order('elements.element_set_id ASC');
-        $select->order('elements.name ASC');
-        return $table->fetchObjects($select);
+        $options = $table->findPairsForSelectForm(array(
+            'record_types' => array('Item', 'All'),
+            'sort' => 'orderBySet'
+        ));
+        $options = apply_filters('elements_select_options', $options);
+        // now format it like the original = set_name : element_name
+        $elements = array();
+        foreach ($options as $setName => $elems) {
+            foreach ($elems as $elemId => $elemName) {
+                $elements[$elemId] = "$setName : $elemName";
+            }
+        }
+        return $elements;
     }
 }

--- a/views/admin/rules/add.php
+++ b/views/admin/rules/add.php
@@ -26,13 +26,18 @@
             </div>
             <div class="five columns omega">
                 <div class="inputs">
-                    <select id="element_ids" name="element_ids[]" multiple="multiple" size="10">
-                        <?php foreach ($elements as $element): ?>
-                            <option value="<?php echo $element->id; ?>">
-                                <?php echo $element->getElementSet()->name . ' : ' . $element->name; ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
+                <?php
+                    echo $this->formSelect(
+                        "element_ids[]",
+                        @$_POST['element_ids'],
+                        array(
+                            'id' => 'element_ids',
+                            'multiple' => true,
+                            'size' => 10,
+                        ), 
+                        $elements
+                    );
+                ?>
                 </div>
             </div>
         </div>

--- a/views/admin/rules/edit.php
+++ b/views/admin/rules/edit.php
@@ -27,15 +27,19 @@
             </div>
             <div class="five columns omega">
                 <div class="inputs">
-                    <select id="element_ids" name="element_ids[]" multiple="multiple" size="10">
-                        <?php $rule_element_ids = unserialize($rule->element_ids); ?>
-                        <?php foreach ($elements as $element): ?>
-                            <?php $selected = in_array($element->id, $rule_element_ids); ?>
-                            <option value="<?php echo $element->id; ?>" <?php if ($selected) { echo 'selected="selected"'; } ?>>
-                                <?php echo $element->getElementSet()->name . ' : ' . $element->name; ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
+                <?php $rule_element_ids = unserialize($rule->element_ids); ?>
+                <?php
+                    echo $this->formSelect(
+                        "element_ids[]",
+                        $rule_element_ids,
+                        array(
+                            'id' => 'element_ids',
+                            'multiple' => true,
+                            'size' => 10,
+                        ), 
+                        $elements
+                    );
+                ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Hi and thanks for great plugin!!

This pull request is only minor fix related to elements:
- it uses the order as defined by users
- it translates the set name and element names
- it applies `elements_select_options` filter, so that other plugins (i.e. `HideElements`) can alter the elements displayed
