### PR TITLE
Allow rules to apply to all itemtypes

### DIFF
--- a/controllers/RulesController.php
+++ b/controllers/RulesController.php
@@ -47,7 +47,7 @@ class ItemDuplicateCheck_RulesController extends Omeka_Controller_AbstractAction
         if (!isset($rule)) {
             $rule = new ItemDuplicateCheckRule;
         }
-        $rule->item_type_id = $item_type_id;
+        $rule->item_type_id = $item_type_id ? $item_type_id : null;
         $rule->element_ids = serialize($element_ids);
         $rule->save();
 

--- a/views/admin/rules/add.php
+++ b/views/admin/rules/add.php
@@ -10,6 +10,7 @@
             <div class="five columns omega">
                 <div class="inputs">
                     <select id="item_type_id" name="item_type_id">
+                        <option value=""></option>
                         <?php foreach ($itemTypes as $itemType): ?>
                             <option value="<?php echo $itemType->id; ?>">
                                 <?php echo $itemType->name; ?>

--- a/views/admin/rules/edit.php
+++ b/views/admin/rules/edit.php
@@ -10,6 +10,7 @@
             <div class="five columns omega">
                 <div class="inputs">
                     <select id="item_type_id" name="item_type_id">
+                        <option value=""></option>
                         <?php foreach ($itemTypes as $itemType): ?>
                             <?php $selected = ($itemType->id == $rule->item_type_id); ?>
                             <option value="<?php echo $itemType->id; ?>" <?php if ($selected):?>selected="selected"<?php endif; ?>>

--- a/views/admin/rules/list.php
+++ b/views/admin/rules/list.php
@@ -15,7 +15,12 @@
     <tbody>
       <?php foreach ($rules as $rule): ?>
         <tr>
-          <td><?php echo $rule->getItemType()->name; ?></td>
+          <td>
+            <?php
+              $itemType = $rule->getItemType();
+              echo $itemType ? $itemType->name : '<em>' . __('All') . '</em>';
+            ?>
+          </td>
           <td>
             <?php
               $element_names = array();


### PR DESCRIPTION
Good add-on. 
I would also change, for better clarity, 
`<option value=""></option>`
into
`<option value="">** <?php echo __('All types'); ?> **</option>`
in both add.php and edit.php

Hope this helps.